### PR TITLE
apply temp fix for Rails 5

### DIFF
--- a/lib/acts_as_taggable_on/taggable/core.rb
+++ b/lib/acts_as_taggable_on/taggable/core.rb
@@ -266,7 +266,8 @@ module ActsAsTaggableOn::Taggable
 
         # Create new taggings:
         new_tags.each do |tag|
-          taggings.create!(tag_id: tag.id, context: context.to_s, taggable: self)
+          t = taggings.new(tag_id: tag.id, context: context.to_s, taggable: self)
+          t.save
         end
       end
 

--- a/lib/acts_as_taggable_on/taggable/core.rb
+++ b/lib/acts_as_taggable_on/taggable/core.rb
@@ -267,7 +267,7 @@ module ActsAsTaggableOn::Taggable
         # Create new taggings:
         new_tags.each do |tag|
           t = taggings.new(tag_id: tag.id, context: context.to_s, taggable: self)
-          t.save
+          t.save!
         end
       end
 


### PR DESCRIPTION
I don't know why this works.

We were getting an error thrown -- `No implicit conversion of nil into String`. The error was coming from the guts of ActiveRecord's postgres adapter. I spent some time following the code down, line by line. I could see that, at some point, the postgres adapter was getting `nil` as a table name, but I couldn't figure out why or how it was getting that. I went through many layers 😭.

Interestingly, I tried swapping `create!` for `create`, but that still threw the error, while `save` did not. My best guess is that a callback somewhere (e.g. an `after_create` hook or something) was interfering, but I couldn't track down what that would be in the `egghead-rails` codebase, nor could I figure out where it was coming from in this codebase.

So, anyway, this fix is intended to be temporary until we upgrade to Rails 5.2. acts_as_taggable_on have released their 5.2 support, so 🤞 hopefully that will work when we get there. If not then it might be time to finish @peterkeen's replacement for this gem.

Basically, I just wanted to unlock the Rails 5 upgrade, so here we are.